### PR TITLE
fix:lock sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "markdown-it": "^13.0.1",
     "markdown-it-container": "^3.0.0",
     "packages": "^0.0.8",
-    "sass": "^1.54.9",
+    "sass": "1.54.9",
     "vite": "^3.1.0",
     "vue": "3.4.21"
   },


### PR DESCRIPTION
since sass 1.77.7,it change mixed and nested rules
more info: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
so.....lock sass fixed version
<img width="831" alt="1" src="https://github.com/user-attachments/assets/e4a7d815-c03a-4430-ad2d-7cf6d80a8228">

